### PR TITLE
flake.nix: add environmentFile option

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,7 @@
         ];
         src = ./.;
         vendorHash = "sha256-RhP9bp2GQd5SyAQ8IzpOiUhPEZqkxhmcEESC9E6AfRM=";
+        meta.mainProgram = "prometheus-plex-exporter";
       };
     });
 
@@ -38,75 +39,103 @@
       pkgs,
       ...
     }: let
+      inherit
+        (lib)
+        getExe
+        mkEnableOption
+        mkIf
+        mkOption
+        optional
+        optionalString
+        toString
+        ;
+
+      inherit
+        (lib.types)
+        bool
+        nullOr
+        package
+        path
+        port
+        str
+        ;
+
       cfg = config.services.prometheus-plex-exporter;
     in {
       options.services.prometheus-plex-exporter = {
-        enable = lib.mkEnableOption "prometheus exporter for plex media server";
+        enable = mkEnableOption "prometheus exporter for plex media server";
 
-        package = lib.mkOption {
-          type = lib.types.package;
+        package = mkOption {
+          type = package;
           default = pkgs.prometheus-plex-exporter;
           description = "Package to use for prometheus-plex-exporter.";
         };
 
-        bindAddress = lib.mkOption {
-          type = lib.types.str;
+        bindAddress = mkOption {
+          type = str;
           default = "";
           description = "Address to bind to, defaults to all interfaces.";
         };
 
-        port = lib.mkOption {
-          type = lib.types.port;
+        port = mkOption {
+          type = port;
           default = 9000;
         };
 
-        user = lib.mkOption {
-          type = lib.types.str;
+        user = mkOption {
+          type = str;
           default = "nobody";
         };
 
-        group = lib.mkOption {
-          type = lib.types.str;
+        group = mkOption {
+          type = str;
           default = "nogroup";
         };
 
-        plexServer = lib.mkOption {
-          type = lib.types.str;
+        plexServer = mkOption {
+          type = str;
           default = "http://localhost:32400";
-          description = "The URL of the Plex server to monitor.";
+          description = "The URL of the Plex server to monitor. Ignored if environmentFile is set.";
         };
 
-        plexToken = lib.mkOption {
-          type = lib.types.str;
-          description = "The Plex token to use to authenticate with the Plex server.";
+        plexToken = mkOption {
+          type = str;
+          description = "The Plex token to use to authenticate with the Plex server. Ignored if environmentFile is set.";
         };
 
-        openFirewall = lib.mkOption {
-          type = lib.types.bool;
+        environmentFile = mkOption {
+          type = nullOr path;
+          default = null;
+          description = "Path to a file containing environment variables to set for the service. Setting this ignores plexServer and plexToken options. Must set PLEX_SERVER and PLEX_TOKEN variables.";
+        };
+
+        openFirewall = mkOption {
+          type = bool;
           default = false;
           description = "Whether to open the firewall for the prometheus-plex-exporter port.";
         };
       };
 
-      config = lib.mkIf cfg.enable {
+      config = mkIf cfg.enable {
         nixpkgs.overlays = [self.overlays.default];
-        networking.firewall.allowedTCPPorts = lib.optional cfg.openFirewall [cfg.port];
+        networking.firewall.allowedTCPPorts = optional cfg.openFirewall [cfg.port];
 
         systemd.services.prometheus-plex-exporter = {
           description = "Prometheus Plex Exporter";
           after = ["network.target"];
           wants = ["network.target"];
-          environment = {
+          environment = mkIf (cfg.environmentFile == null) {
             PLEX_SERVER = cfg.plexServer;
             PLEX_TOKEN = cfg.plexToken;
           };
           serviceConfig = {
+            EnvironmentFile = mkIf (cfg.environmentFile != null) cfg.environmentFile;
             User = "${cfg.user}";
             Group = "${cfg.group}";
             ExecStart = ''
-              ${cfg.package}/bin/prometheus-plex-exporter \
-              ${lib.optionalString (cfg.bindAddress != "") "--bind-addr ${cfg.bindAddress}"} \
-              ${lib.optionalString (cfg.port != 9000) ("--port " + toString cfg.port)}
+              ${getExe cfg.package} \
+              ${optionalString (cfg.bindAddress != "") "--bind-addr ${cfg.bindAddress}"} \
+              ${optionalString (cfg.port != 9000) ("--port " + toString cfg.port)}
             '';
             Restart = "on-failure";
           };


### PR DESCRIPTION
Refactor to use inherit for DRY on lib.

Add environment file support for sops secrets use.